### PR TITLE
Change dependabot interval to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,8 @@ updates:
     directory: "/" # Location of package manifests
     target-branch: "main"
     schedule:
-      interval: "weekly"
+      interval: "daily"
+      time: "04:00"
     open-pull-requests-limit: 5
     commit-message:
       prefix: "(chore)"


### PR DESCRIPTION
5 PRs weekly is not enough for the amount of dependencies we have, if we want to keep dependencies up to date, we should have option to take care of it more often - at least from start. (E.g now all `@redhat-cloud-services` are outdated)

I taken the interval from [image-builder](https://github.com/RedHatInsights/image-builder-frontend/blob/main/.github/dependabot.yml). I am open to disscuss different numbers, but remember that the limit is for opened PRs, so when limit is 5 and 5 is opened next day it will still be 5.
