### PR TITLE
Fix jest config moduleDirectories

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,9 +10,6 @@ module.exports = {
   roots: ['<rootDir>/src/'],
   transformIgnorePatterns: ['node_modules/(?!@patternfly|lodash-es|@openshift|@redhat-cloud-services)'],
   testEnvironment: 'jest-environment-jsdom',
-  moduleDirectories: [
-    'node_modules',
-    './src', //the root directory
-  ],
+  moduleDirectories: ['node_modules', '<rootDir>/src'],
   setupFilesAfterEnv: ['<rootDir>/config/jest.setup.js'],
 };


### PR DESCRIPTION
**OAMG-10380**

Tests fails due to invalid config, when we wanted to bump version of some libraries, e.g. https://github.com/RedHatInsights/in-place-upgrades-frontend/pull/156

